### PR TITLE
New features - update doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@ In a nutshell, the BacPack system contains these Components:
  - Package Context
  - Package Tracker
  - Project
+ - CMCONF system
 
 The interactions and relationships between these Components are shown on next diagram.
 
@@ -32,6 +33,7 @@ classDiagram
     class PackageRepository
     class Package
     class Project
+    class CMCONFSystem
     class PackageTracker
 
     %% CORE RELATIONSHIPS
@@ -56,6 +58,9 @@ classDiagram
 
     %% Project uses PackageTracker (Composition - Project owns its tracker)
     Project *-- PackageTracker : uses
+
+    %% Project uses CMCONF system
+    Project --> CMCONFSystem : sets
 
     %% PackageTracker interacts with repository and creates sysroot (Association)
     PackageTracker --> PackageRepository : retrieves Packages from
@@ -126,8 +131,8 @@ Package Tracker provides CMake macros that handle downloading, caching, and inte
 Packages/Apps from Package Repository. Projects link to Package Tracker repository to use Packages
 built in Package Repository.
 
-The Package Tracker links to a Package Repository. This link must be changed to work with Project
-specific Package Repository.
+The Project which uses Package Tracker must set its CMCONF system, which sets among other things
+the Package Repository URI, so the Package Tracker knows which Package Repository to use.
 
 ```mermaid
 ---
@@ -145,6 +150,10 @@ classDiagram
   }
 
   Project --> PackageTracker : uses
+  Project --> CMCONFSystem : sets
+
+  %% PackageTracker uses CMCONF system
+  CMCONFSystem --> PackageTracker : retrieves Package Repository URI
 
   %% PackageTracker interacts with repository and creates sysroot (Association)
   PackageTracker --> PackageRepository : retrieves Packages from
@@ -262,6 +271,13 @@ classDiagram
     PackageConfig ..> PackageConfig : depends on
 ```
 
+#### CMCONF system
+
+The CMCONF system is a global configuration that specifies configuration needed by Package Tracker.
+It uses the [CMCONF](https://github.com/cmakelib/cmakelib-component-cmconf) component of cmakelib.
+
+Projects must use this system in order to access Packages from the Package Repository.
+
 ### External tools
 
 #### cmakelib
@@ -278,6 +294,8 @@ specific functionality and has its own git repository. The components are:
  other cmakelib components
  - [STORAGE](https://github.com/cmakelib/cmakelib-component-storage) - mechanism for storing and
  retrieving build dependencies
+ - [CMCONF](https://github.com/cmakelib/cmakelib-component-cmconf) - global configuration system
+ for CMake projects
 
 The links between cmakelib and other Components are shown on next diagram.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,7 @@ classDiagram
   Project --> CMCONFSystem : sets
 
   %% PackageTracker uses CMCONF system
-  CMCONFSystem --> PackageTracker : retrieves Package Repository URI
+  PackageTracker --> CMCONFSystem : retrieves Package Repository URI
 
   %% PackageTracker interacts with repository and creates sysroot (Association)
   PackageTracker --> PackageRepository : retrieves Packages from
@@ -293,7 +293,7 @@ specific functionality and has its own git repository. The components are:
  - [CMUTIL](https://github.com/cmakelib/cmakelib-component-cmutil) - Provides functionality for
  other cmakelib components
  - [STORAGE](https://github.com/cmakelib/cmakelib-component-storage) - mechanism for storing and
- retrieving build dependencies
+ retrieving CMake dependencies
  - [CMCONF](https://github.com/cmakelib/cmakelib-component-cmconf) - global configuration system
  for CMake projects
 
@@ -317,6 +317,9 @@ classDiagram
 
     %% CMLibStorage uses cmakelib (Association)
     cmakelib *-- CMLibStorage : is component of
+
+    cmakelib *-- CMCONF : is component of
+    cmakelib *-- CMDEF : is component of
 ```
 
 The interactions between cmakelib and other Components when building a Project are shown on next diagram.
@@ -326,11 +329,14 @@ sequenceDiagram
   actor User
   participant Project
   participant cmakelib
+  participant CMDEF
   participant CMLibStorage
   participant Package Tracker
 
   User->>Project: Initiates Project<br>configuration
   Project->>cmakelib: Includes cmakelib with<br>STORAGE component
+  cmakelib->>CMDEF: CMDEF environment<br>initialization
+  CMDEF->>cmakelib: CMDEF environment<br>initialized
   cmakelib->>CMLibStorage: Asks for storage<br>initialization
   Package Tracker->>CMLibStorage: Retrieves Package<br>Tracker
   CMLibStorage->>CMLibStorage: Package<br>Tracker initialization

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,6 +269,16 @@ classDiagram
 Dependency tracking library for CMake. It defines macros for dependency tracking and features
 caching for efficient use and building of dependencies.
 
+It has several components, which can be used independently or together. Each component provides
+specific functionality and has its own git repository. The components are:
+
+ - [CMDEF](https://github.com/cmakelib/cmakelib-component-cmdef) - adds wrappers for basic CMake
+ features
+ - [CMUTIL](https://github.com/cmakelib/cmakelib-component-cmutil) - Provides functionality for
+ other cmakelib components
+ - [STORAGE](https://github.com/cmakelib/cmakelib-component-storage) - mechanism for storing and
+ retrieving build dependencies
+
 The links between cmakelib and other Components are shown on next diagram.
 
 ```mermaid

--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -298,13 +298,16 @@ The creation of Package Repository is basically creating an empty git repository
 commands will create it in the current directory:
 
 ```bash
-mkdir package_repo && cd package_repo && git init && git lfs install
+mkdir package_repo && cd package_repo && git init
 ```
 
-!!! note
-    The Packages are usually large in size, so it is recommended to use git lfs for storing them.
-    If the Package Repository is used only locally, the git lfs is not necessary. Packager does not
-    require it.
+The Packages are usually large in size, so it is recommended to use git lfs for storing them.
+If the Package Repository is used only locally, the git lfs is not necessary. Packager does not
+require it. To set up git lfs, run following command in the Package Repository directory: 
+
+```bash
+git lfs install && git lfs track "*.zip" && git add .gitattributes && git commit -m "Initial commit"
+```
 
 ### Build a Package
 
@@ -365,9 +368,13 @@ a system config file present in its repository at `config/CMCONF_EXAMPLEConfig.c
     variables are described in the
     [Package Tracker documentation](https://github.com/bacpack-system/package-tracker/blob/master/doc/GlobalConfiguration.md).
 
-    With this configuration, Package Tracker will download Packages from upstream BringAuto's
-    Package Repository by default. In this example, this behavior will be overridden later on to
-    use the local Package Repository created in previous steps.
+    The BA_PACKAGE_URI_TEMPLATE_REMOTE variable is set to a general URI. The actual URI is set in
+    the App's `CMakeLists.txt` file. Important part of the URI template are fields in <> brackets,
+    which are replaced by actual values when downloading a Package.
+
+    With this configuration, Package Tracker will download Packages from upstream Package
+    Repository referenced in the URI template by default. In this example, this behavior will be
+    overridden later on to use the local Package Repository created in previous steps.
 
     ```cmake
     #
@@ -389,7 +396,7 @@ a system config file present in its repository at `config/CMCONF_EXAMPLEConfig.c
 
     # Setting BringAuto's Package Repository URI Template
     CMCONF_SET(BA_PACKAGE_URI_REVISION master)
-    CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.bringauto.com/fleet-protocol/package-repository/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+    CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.com/some/path/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
     ```
 
 After creating the config file, the CMCONF system must be installed with CMake. The following
@@ -437,7 +444,7 @@ This configuration is sufficient for using Packages from upstream BringAuto's Pa
 To use the local Package Repository created in previous steps instead, add the following code:
 
 ```cmake
-# Setting using local Package Repository for this App.
+# Setting using local Package Repository for this App. The path must be absolute.
 CMCONF_SET(BA_PACKAGE_LOCAL_USE ON)
 CMCONF_SET(BA_PACKAGE_LOCAL_PATH "/package_repo")
 ```

--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -38,7 +38,7 @@ mkdir context && cd context && mkdir docker package app && git init
 
 The [example Package Context](https://github.com/bacpack-system/example-context)
 contains complete Package Context for this tutorial with all `curl` and `zlib` Configs,
-`example-project` app and `ubuntu2404` and `fedora41` Dockerfiles.
+`example-project` app and `ubuntu2404` and `fedora42` Dockerfiles.
 
 ??? example "Package Context directory structure"
 
@@ -56,7 +56,7 @@ contains complete Package Context for this tutorial with all `curl` and `zlib` C
     │   │   └── Dockerfile
     │   ├── ubuntu2404
     │   │   └── Dockerfile
-    │   └── fedora41
+    │   └── fedora42
     │       └── Dockerfile
     │       ...
     ├── app
@@ -112,14 +112,14 @@ used in the Package Configs to specify the Docker image to use for building the 
 Dockerfile must be named `Dockerfile`.
 
 ??? example "Dockerfile example"
-    The following Dockerfile is used for building `curl` and `zlib` Packages for Fedora 41. It
+    The following Dockerfile is used for building `curl` and `zlib` Packages for Fedora 42. It
     installs all required tools and fulfills all
     [requirements](https://github.com/bacpack-system/packager/blob/master/doc/DockerContainerRequiremetns.md).
-    The path to this Dockerfile is `context/docker/fedora41/Dockerfile`. The `fedora41` is the
+    The path to this Dockerfile is `context/docker/fedora42/Dockerfile`. The `fedora42` is the
     name of the Docker image and is used in the Package Configs.
 
     ```docker
-    FROM fedora:41
+    FROM fedora:42
 
     USER root
     RUN echo root:1234 | chpasswd
@@ -220,7 +220,7 @@ Configs.
       "DockerMatrix": {
         "ImageNames": [
           "ubuntu2404",
-          "fedora41"
+          "fedora42"
         ]
       }
     }
@@ -257,7 +257,7 @@ Configs.
       "DockerMatrix": {
         "ImageNames": [
           "ubuntu2404",
-          "fedora41"
+          "fedora42"
         ]
       }
     }
@@ -284,7 +284,7 @@ Following command builds a Docker image based on Dockerfile in given Package Con
 ```bash
 bap-builder build-image \
             --context context \
-            --image-name fedora41
+            --image-name fedora42
 ```
 
 ### Create a Package Repository
@@ -322,12 +322,12 @@ The command for building `curl` Package is:
 ```bash
 bap-builder build-package \
             --context context \
-            --image-name fedora41 \
+            --image-name fedora42 \
             --output-dir package_repo \
             --name curl --build-deps
 ```
 
-This command builds a Package `curl` defined in Context for `fedora41` image, creates an archive
+This command builds a Package `curl` defined in Context for `fedora42` image, creates an archive
 of this Package and copies it to the output-dir (Package Repository). The command with
 `--build-deps` flag also builds all dependencies of the given Package. In this case it also builds
 the `zlib` Package. Other flags and settings of Packager are described in its
@@ -477,7 +477,7 @@ Now the App can be added to a Package Context.
       },
       "DockerMatrix": {
         "ImageNames": [
-          "fedora41"
+          "fedora42"
         ]
       }
     }
@@ -490,7 +490,7 @@ This App can be built using Packager with following command:
 ```bash
 bap-builder build-app \
             --context context \
-            --image-name fedora41 \
+            --image-name fedora42 \
             --output-dir package_repo \
             --name example-project
 ```
@@ -499,7 +499,7 @@ After this command, the Packager creates a zip archive of the App. If it is extr
 structure looks like this:
 
 ```plaintext
-example-project_v1.0.0_x86-64-fedora-41
+example-project_v1.0.0_x86-64-fedora-42
 ├── bin
 │   └── example-project
 └── lib
@@ -520,4 +520,4 @@ example-project_v1.0.0_x86-64-fedora-41
 
 As can be seen, the extracted structure contains the `example-project` binary in `bin` directory
 and all its dependencies in `lib` directory. Now the App can be easily extracted to a system based
-on fedora41 image.
+on fedora42 image.

--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -343,7 +343,9 @@ following steps. The Project uses `curl` Package built in previous steps as a de
 ### Install cmakelib
 
 First, cmakelib (link in [Introduction](./index.md)) must be installed. Follow the README to
-install it.
+install it. Several cmakelib components will be used in following sections, but cmakelib installs
+them all automatically. More information about these components is in
+[System level architecture](./architecture.md/#cmakelib).
 
 ### Set the Package Tracker
 
@@ -397,15 +399,6 @@ FIND_PACKAGE(CURL REQUIRED)
 
     The `ZLIB_ROOT` is a helper variables for `zlib` Package, because `zlib` does not provide a
     CMake config file.
-
-!!! note
-
-    Each of the cmakelib components has its own git repository and adds specific functionality.
-    Any or none of the following components can be used:
-
-     - [CMDEF](https://github.com/cmakelib/cmakelib-component-cmdef) - adds wrappers for basic CMake features
-     - [CMUTIL](https://github.com/cmakelib/cmakelib-component-cmutil) - Provides functionality for other cmakelib components
-     - [STORAGE](https://github.com/cmakelib/cmakelib-component-storage) - mechanism for storing and retrieving build dependencies
 
 ### Build a Project
 

--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -348,7 +348,7 @@ following steps. The Project uses `curl` Package built in previous steps as a de
 First, cmakelib (link in [Introduction](./index.md)) must be installed. Follow the README to
 install it. Several cmakelib components will be used in following sections, but cmakelib installs
 them all automatically. More information about these components is in
-[System level architecture](./architecture.md/#cmakelib).
+[System level architecture](./architecture.md#cmakelib).
 
 ### Install CMCONF system
 

--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -298,8 +298,13 @@ The creation of Package Repository is basically creating an empty git repository
 commands will create it in the current directory:
 
 ```bash
-mkdir package_repo && cd package_repo && git init
+mkdir package_repo && cd package_repo && git init && git lfs install
 ```
+
+!!! note
+    The Packages are usually large in size, so it is recommended to use git lfs for storing them.
+    If the Package Repository is used only locally, the git lfs is not necessary. Packager does not
+    require it.
 
 ### Build a Package
 

--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -347,33 +347,114 @@ install it. Several cmakelib components will be used in following sections, but 
 them all automatically. More information about these components is in
 [System level architecture](./architecture.md/#cmakelib).
 
-### Set the Package Tracker
+### Install CMCONF system
+
+The Package Tracker requires a global configuration, which is provided by CMCONF system. This
+system is defined by a config file that sets all required variables for the Package Tracker. The
+config file must be named `CMCONF_<SYSTEM_NAME>Config.cmake`, where `<SYSTEM_NAME>` is an arbitrary
+system name that must match the name used in `CMCONF_INIT_SYSTEM(<SYSTEM_NAME>)` macro in
+`CMLibStorage.cmake`. The [example Project](https://github.com/bacpack-system/example-project) uses
+a system config file present in its repository at `config/CMCONF_EXAMPLEConfig.cmake`.
+
+??? example "CMCONF system for Package Tracker config example"
+    The following config defines a CMCONF system for Package Tracker. The system name is `EXAMPLE`.
+    It sets all required variables for the Package Tracker.
+
+    First, `CMLIB` is found with the `CMCONF` component. Then the system is initialized with the
+    `CMCONF_INIT_SYSTEM` macro. Finally, the variables are set with the `CMCONF_SET` macro. The
+    variables are described in the
+    [Package Tracker documentation](https://github.com/bacpack-system/package-tracker/blob/master/doc/GlobalConfiguration.md).
+
+    With this configuration, Package Tracker will download Packages from upstream BringAuto's
+    Package Repository by default. In this example, this behavior will be overridden later on to
+    use the local Package Repository created in previous steps.
+
+    ```cmake
+    #
+    # Example configuration for CMCONF system.
+    #
+
+    FIND_PACKAGE(CMLIB REQUIRED COMPONENTS CMCONF)
+
+    CMCONF_INIT_SYSTEM(EXAMPLE)
+
+    # Setting using upstream Package Repository by default for this system. This can be overridden by
+    # App in CMakeLists.txt.
+    CMCONF_SET(BA_PACKAGE_LOCAL_USE OFF)
+    CMCONF_SET(BA_PACKAGE_LOCAL_PATH "")
+
+    # The http authorization header is usually used for accessing private Package Repositories. This
+    # example does not need it, but the variable must be set.
+    CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "")
+
+    # Setting BringAuto's Package Repository URI Template
+    CMCONF_SET(BA_PACKAGE_URI_REVISION master)
+    CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.bringauto.com/fleet-protocol/package-repository/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+    ```
+
+After creating the config file, the CMCONF system must be installed with CMake. The following
+command installs it:
+
+```bash
+cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P config/CMCONF_EXAMPLEConfig.cmake
+```
+
+After this command, the CMCONF system is globally installed and can be used by multiple Projects.
+If user wants to uninstall the system, following command can be used:
+
+```bash
+cmake -DCMCONF_UNINSTALL=ON -P config/CMCONF_EXAMPLEConfig.cmake
+```
+
+### Set the `CMLibStorage.cmake` file
 
 In the Project root directory, the `CMLibStorage.cmake` needs to be added with the following content:
 
 ```cmake
+FIND_PACKAGE(CMLIB COMPONENTS CMCONF REQUIRED)
+
+# Adding CMCONF system
+CMCONF_INIT_SYSTEM(EXAMPLE)
+
+# Defining list of storages
 SET(STORAGE_LIST DEP)
+
+# Defining Package Tracker storage url
 SET(STORAGE_LIST_DEP "https://github.com/bacpack-system/package-tracker.git")
 ```
+
+First, `CMLIB` is found with the `CMCONF` component in order to initialize the CMCONF system,
+which is done with the `CMCONF_INIT_SYSTEM` macro. Finally, the Package Tracker URL is defined.
 
 !!! info
 
     The `CMLibStorage.cmake` file is a part of STORAGE component of cmakelib. So this component
-    must be enabled with cmakelib. The `STORAGE_LIST` variable defines the list of storages and
-    `STORAGE_LIST_<STORAGE>` defines the URL for each storage. In this case the Package Tracker
-    is used.
+    must be enabled with cmakelib (in `CMakeLists.txt`). The `STORAGE_LIST` variable defines the
+    list of storages and `STORAGE_LIST_<STORAGE>` defines the URL for each storage. In this case
+    the Package Tracker is used.
 
-This links the Project with Package Tracker, which by default enables adding Packages from
-BringAuto's specific Package Repository (The Package Tracker points to Package Repository). Usually
-the previously built Packages would be used, but for simplicity, the same Packages from BringAuto's
-specific Package Repository are used instead. These Packages are exactly the same as Packages
-defined in [example Package Context](https://github.com/bacpack-system/example-context).
+This configuration is sufficient for using Packages from upstream BringAuto's Package Repository.
+To use the local Package Repository created in previous steps instead, add the following code:
+
+```cmake
+# Setting using local Package Repository for this App.
+CMCONF_SET(BA_PACKAGE_LOCAL_USE ON)
+CMCONF_SET(BA_PACKAGE_LOCAL_PATH "/package_repo")
+```
+
+or export `BA_PACKAGE_LOCAL_PATH` environment variable before running `cmake`:
+
+```bash
+export BA_PACKAGE_LOCAL_PATH=/package_repo
+```
+
+The path must be set to the actual absolute path of the Package Repository.
 
 !!! note
 
-    The local Package Repository can't be easily used when building a Project, because currently
-    the BacPack system supports only upstream Package Repositories. The usage of local Package
-    Repository will be added in future releases.
+    Even without setting local Package Repository, the Project will be built successfully. It is
+    because the `curl` and `zlib` Packages are already built and available in upstream BringAuto's
+    Package Repository.
 
 ### Configure CMakeLists
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,10 @@ or organization:
  - **Package Context** - A directory structure containing configuration files that define how to
  build Packages, including build settings and Docker environments.
 
+ - **CMCONF system** - Global configuration that specifies information needed by Package Tracker
+ (including URI to Package Repository), it uses the
+ [CMCONF](https://github.com/cmakelib/cmakelib-component-cmconf) component of cmakelib
+
 These Components are customized for each Project's specific needs - different Projects will have
 different Packages to build and different build requirements.
 

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -81,10 +81,10 @@ sequenceDiagram
   participant Package Repository
   participant Package Context
 
-  User->>Packager: Initiates Package build
+  User->>+Packager: Initiates Package build
   Package Context->>Packager: Retrieves Package definitions
   Packager->>Packager: Package build
-  Packager->>Package Repository: Uploads built Packages
+  Packager->>-Package Repository: Uploads built Packages
 ```
 
 ## Use already built Packages in Project
@@ -104,7 +104,7 @@ sequenceDiagram
   User->>CMCONF system: Installs CMCONF system
   User->>Project: Puts link of Package Tracker
   User->>Project: Adds desired Package to CMakeLists
-  User->>Project: Initiates Project build
+  User->>+Project: Initiates Project build
   rect
     Note right of Package Repository: Project build
     Project->>+Package Tracker: Asks for Packages
@@ -112,6 +112,6 @@ sequenceDiagram
     Package Repository->>Package Tracker: Retrieves Packages
     Package Tracker->>-Project: Adds Packages to build
     Project->>Project: FIND_PACKAGE<br>for each Package
-    Project->>Project: Project build
+    Project->>-Project: Project build
   end
 ```

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -21,8 +21,6 @@ sequenceDiagram
   participant Packager
   participant Package Repository
   participant Package Context
-  participant Package Tracker
-  participant Project
 
   User->>Package Context: Adds Package definition
   User->>Packager: Build Package
@@ -40,8 +38,6 @@ sequenceDiagram
   participant Packager
   participant Package Repository
   participant Package Context
-  participant Package Tracker
-  participant Project
 
   User->>Package Context: Updates Package definition
   opt if version tag changed
@@ -52,17 +48,14 @@ sequenceDiagram
 
 ### Remove Package
 
-Removing a Package from Package Context means removing the Package Config from Package Context
-and then removing the Package from the Package Repository.
+Removing a Package means removing the Package Config from Package Context and then removing the
+Package from the Package Repository.
 
 ```mermaid
 sequenceDiagram
   actor User
-  participant Packager
   participant Package Repository
   participant Package Context
-  participant Package Tracker
-  participant Project
 
   User->>Package Context: Remove Package definition
   User->>Package Repository: Remove Package
@@ -87,8 +80,6 @@ sequenceDiagram
   participant Packager
   participant Package Repository
   participant Package Context
-  participant Package Tracker
-  participant Project
 
   User->>Packager: Initiates Package build
   Package Context->>Packager: Retrieves Package definitions
@@ -105,9 +96,7 @@ be set in `CMLibStorage.cmake` in the root directory of the application.
 ```mermaid
 sequenceDiagram
   actor User
-  participant Packager
   participant Package Repository
-  participant Package Context
   participant Package Tracker
   participant Project
   participant CMCONF system

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -110,15 +110,18 @@ sequenceDiagram
   participant Package Context
   participant Package Tracker
   participant Project
+  participant CMCONF system
 
+  User->>CMCONF system: Installs CMCONF system
   User->>Project: Puts link of Package Tracker
   User->>Project: Adds desired Package to CMakeLists
   User->>Project: Initiates Project build
   rect
     Note right of Package Repository: Project build
-    Project->>Package Tracker: Asks for Packages
+    Project->>+Package Tracker: Asks for Packages
+    CMCONF system->>Package Tracker: Retrieves Package Repository location
     Package Repository->>Package Tracker: Retrieves Packages
-    Package Tracker->>Project: Adds Packages to build
+    Package Tracker->>-Project: Adds Packages to build
     Project->>Project: FIND_PACKAGE<br>for each Package
     Project->>Project: Project build
   end


### PR DESCRIPTION
New features are being added to BacPack system:

- global configurations
- using local Package Repositories

The purpose of this PR is to document these new features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a global CMCONF system across architecture, index, use-case, and package-tracker docs; diagrams and flows show CMCONF providing the Package Repository URI to the tracker.
  * Expanded cmakelib overview to include CMCONF and its components, plus CMCONF-centric sequence/class diagrams.
  * Updated example usage to Fedora 42 (images, paths, commands, artifacts) and added Git LFS guidance.
  * Added CMCONF installation/configuration and local vs upstream repository usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->