### PR TITLE
Update links

### DIFF
--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -95,7 +95,7 @@ The following sections describe how to define Docker images and Packages.
 
 The Packages are built inside a Docker container created from image specified by Dockerfile.
 The image defines a build environment for building Packages. Defined Docker image must comply
-with some [requirements](https://github.com/bacpack-system/packager/blob/master/doc/DockerContainerRequiremetns.md),
+with some [requirements](https://github.com/bacpack-system/packager/blob/master/doc/DockerContainerRequirements.md),
 briefly:
 
  - CMake must be installed,
@@ -114,7 +114,7 @@ Dockerfile must be named `Dockerfile`.
 ??? example "Dockerfile example"
     The following Dockerfile is used for building `curl` and `zlib` Packages for Fedora 42. It
     installs all required tools and fulfills all
-    [requirements](https://github.com/bacpack-system/packager/blob/master/doc/DockerContainerRequiremetns.md).
+    [requirements](https://github.com/bacpack-system/packager/blob/master/doc/DockerContainerRequirements.md).
     The path to this Dockerfile is `context/docker/fedora42/Dockerfile`. The `fedora42` is the
     name of the Docker image and is used in the Package Configs.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Fixed two broken links in the example usage documentation by correcting the reference from a misspelled Docker requirements page to the correct one. This improves navigation, reduces confusion during setup, and ensures readers reach the intended guidance. No application functionality, APIs, or behaviors were changed; this update strictly improves documentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->