### PR TITLE
Add Meson mentions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,8 @@ classDiagram
 
 #### Packager
 
-Packager is a tool for building Packages and Apps. It takes a Package Context as an input.
+Packager is a tool for building Packages and Apps. It takes a Package Context as an input. It
+supports both CMake and Meson build systems for building Packages.
 
 Both `build-package` and `build-app` commands build Package or App specified in Package Context
 in a Docker container based on existing Docker image built by `build-image` command, create a zip

--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -98,7 +98,7 @@ The image defines a build environment for building Packages. Defined Docker imag
 with some [requirements](https://github.com/bacpack-system/packager/blob/master/doc/DockerContainerRequirements.md),
 briefly:
 
- - CMake must be installed,
+ - CMake or Meson must be installed,
  - SSH must be configured with root login and password `1234`,
  - and `uname` must be installed.
 
@@ -160,9 +160,9 @@ use, the CMake options, etc. The Config structure is described in
 Some of the important fields of Config are:
 
  - `DependsOn` - list of dependency Packages, all Packages in the list must be defined in the same Package Context
- - `Git/URI` - URI to a CMake based git repository with source code of the Package
- - `Git/Revision` - tag or branch to use for build
- - `Build/CMake/Defines` - CMake options
+ - `Git/URI` - URI to a CMake or Meson based git repository with source code of the Package
+ - `Git/Revision` - tag, branch or commit to use for build
+ - `Build/CMake/Defines` - CMake options (or `Build/Meson/Options` and `Build/Meson/Defines` for Meson)
  - `Package/Name` - name of the Package
  - `DockerMatrix/ImageNames` - list of Docker images to build the Package for
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Architecture docs now reflect support for both CMake and Meson.
  - Clarified packaging flow: files are archived (not just zipped) and copied to the Package Repository.
  - Public API diagram documents a sysroot creation capability in the Packager.
  - Example usage updated to include Meson options alongside CMake.
  - Git revision guidance expanded to allow tag, branch, or commit.
  - Minor wording refinements and error guidance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->